### PR TITLE
Fix src, forked from willscripted. blittle/sinon.js repo is removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "keywords": [
     "sinonjs"
   ],
-  "author": "forked from https://github.com/blittle/sinon.js",
+  "author": "forked from https://github.com/willscripted/sinon.js",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/Polymer/sinon.js/issues"


### PR DESCRIPTION
This repo `https://github.com/blittle/sinon.js` which is deleted
